### PR TITLE
Test pipeline for new macOS 10.15 build machines

### DIFF
--- a/.buildkite/macos-10.15.yml
+++ b/.buildkite/macos-10.15.yml
@@ -101,4 +101,4 @@ steps:
       - npm ci --registry https://registry.npmjs.org
       - cd test/aws-lambda
       - bundle install
-      - bundle exec maze-runner
+      - bundle exec maze-runner features/handled.feature

--- a/.buildkite/macos-10.15.yml
+++ b/.buildkite/macos-10.15.yml
@@ -39,12 +39,6 @@ steps:
   #
   # Expo tests
   #
-  - label:  'TEMP TEST'
-    timeout_in_minutes: 3
-    agents:
-      queue: "opensource"
-    command: "echo Test"
-
   - label:  ':docker: Build expo publisher'
     key: "expo-publisher"
     timeout_in_minutes: 30

--- a/.buildkite/macos-10.15.yml
+++ b/.buildkite/macos-10.15.yml
@@ -1,0 +1,104 @@
+steps:
+  #
+  # Cocoa tests
+  #
+  - label: 'macOS 10.15 E2E tests (subset)'
+    depends_on:
+      - cocoa_fixture
+    timeout_in_minutes: 30
+    plugins:
+      artifacts#v1.3.0:
+        download: ["test/bugsnag-cocoa/features/fixtures/macos/output/macOSTestApp.zip"]
+        upload: ["test/bugsnag-cocoa/macOSTestApp.log", "test/bugsnag-cocoa/appium_server.log"]
+    commands:
+      - cd test/bugsnag-cocoa
+      - bundle install
+      - bundle exec maze-runner
+        --farm=local
+        --os=macos
+        --os-version=10.15
+        --app=macOSTestApp
+        --tags='not @skip_macos'
+        --fail-fast
+        features/barebone_tests.feature
+
+  #
+  # React Native tests
+  #
+  - label: 'Build React Native test fixture for iOS'
+    key: "rn-0-60-ipa"
+    timeout_in_minutes: 30
+    env:
+      REACT_NATIVE_VERSION: rn0.60
+      NOTIFIER_VERSION: 7.10.1
+    artifact_paths: test/bugsnag-js/build/rn0.60.ipa
+    commands:
+      - cd test/bugsnag-js
+      - npm run test:build-react-native-ios
+
+  #
+  # Expo tests
+  #
+  - label:  'TEMP TEST'
+    timeout_in_minutes: 3
+    agents:
+      queue: "opensource"
+    command: "echo Test"
+
+  - label:  ':docker: Build expo publisher'
+    key: "expo-publisher"
+    timeout_in_minutes: 30
+    agents:
+      queue: "opensource"
+    env:
+      EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
+    plugins:
+      - docker-compose#v3.7.0:
+          config: test/bugsnag-js/docker-compose.yml
+          build: expo-publisher
+          image-repository: 855461928731.dkr.ecr.us-west-1.amazonaws.com/js
+          cache-from:
+            - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-platforms-infra
+      - docker-compose#v3.7.0:
+          config: test/bugsnag-js/docker-compose.yml
+          push:
+            - expo-publisher:855461928731.dkr.ecr.us-west-1.amazonaws.com/js:expo-publisher-platforms-infra
+
+  - label: ':docker: Publish expo app'
+    key: "publish-expo-app"
+    depends_on: "expo-publisher"
+    timeout_in_minutes: 20
+    agents:
+      queue: "opensource-highpower"
+    env:
+      EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
+    plugins:
+      - docker-compose#v3.7.0:
+          config: test/bugsnag-js/docker-compose.yml
+          run: expo-publisher
+
+  - label: ':docker: Build expo IPA'
+    key: "build-expo-ipa"
+    depends_on:
+      - "publish-expo-app"
+    timeout_in_minutes: 20
+    env:
+      EXPO_RELEASE_CHANNEL: ${BUILDKITE_BUILD_ID}
+    artifact_paths: build/output.ipa
+    commands:
+      - cd test/bugsnag-js
+      - test/expo/scripts/build-ios.sh
+
+  #
+  # SAM
+  #
+  - label: ':aws-lambda: AWS Lambda tests'
+    timeout_in_minutes: 35
+    commands:
+      # force the NPM registry as the default on CI is artifactory, which can't
+      # currently install from our lockfile
+      - cd test/bugsnag-js
+      - npm ci --registry https://registry.npmjs.org
+      - cd test/aws-lambda
+      - bundle install
+      - bundle exec maze-runner

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -3,9 +3,9 @@
 if [[ "$SERVER_TEST" == "11" ]]; then
   buildkite-agent pipeline upload .buildkite/macos-11.yml
   buildkite-agent pipeline upload .buildkite/build-test-fixtures.yml
-# Placeholders for 10.15 and earlier
-#elif [[ "$SERVER_TEST" == "10.15" ]]; then
-#  buildkite-agent pipeline upload .buildkite/macos-10.15.yml
+elif [[ "$SERVER_TEST" == "10.15" ]]; then
+  buildkite-agent pipeline upload .buildkite/macos-10.15.yml
+  buildkite-agent pipeline upload .buildkite/build-test-fixtures.yml
 #elif [[ "$SERVER_TEST" == "10.14" ]]; then
 #  buildkite-agent pipeline upload .buildkite/macos-10.14.yml
 #elif [[ "$SERVER_TEST" == "10.13" ]]; then

--- a/mac-servers/general/download_secrets.sh
+++ b/mac-servers/general/download_secrets.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-aws s3 --profile=opensource cp s3://bugsnag-opensource-buildkite-secrets/platforms-infra/.npmrc .
-aws s3 --profile=opensource cp s3://bugsnag-opensource-buildkite-secrets/platforms-infra/buildkite-agent.cfg .
-aws s3 --profile=opensource cp s3://bugsnag-opensource-buildkite-secrets/platforms-infra/environment .
+aws s3 --profile=opensource cp s3://bugsnag-opensource-buildkite-secrets/platforms-infrastructure/.npmrc .
+aws s3 --profile=opensource cp s3://bugsnag-opensource-buildkite-secrets/platforms-infrastructure/buildkite-agent.cfg .
+aws s3 --profile=opensource cp s3://bugsnag-opensource-buildkite-secrets/platforms-infrastructure/environment .
 
 mkdir -p expo
-aws s3 --profile=opensource cp s3://bugsnag-opensource-buildkite-secrets/platforms-infra/expo/Certificates.p12 expo
-aws s3 --profile=opensource cp s3://bugsnag-opensource-buildkite-secrets/platforms-infra/expo/Expotest.mobileprovision expo
+aws s3 --profile=opensource cp s3://bugsnag-opensource-buildkite-secrets/platforms-infrastructure/expo/Certificates.p12 expo
+aws s3 --profile=opensource cp s3://bugsnag-opensource-buildkite-secrets/platforms-infrastructure/expo/Expotest.mobileprovision expo


### PR DESCRIPTION
## Goal

Adds a pipeline for testing newly set up macOS 10.15 build servers, prior to adding them to the live pool.

## Design

Follows the recently established pattern for macOS 11, backed by an internal Confluence page (which we will try to absorb into the repo over time).

## Changeset

The secrets bucket name has also changed, having moved from a private to (new) public git repo.  Being private caused too many issue for the pipeline and there is now no reason why the repo can't be open source.

## Testing

Tested as part of setting up a batch of new 10.15 build servers.