### PR TITLE
Various updates

### DIFF
--- a/mac-servers/general/setup-server.sh
+++ b/mac-servers/general/setup-server.sh
@@ -1,5 +1,5 @@
 if [[ ! -d /Users/administrator ]]; then
-    echo /Users/administrator does not exist, exiting.
+    echo /Users/administrator does not exist, exiting.  Consider adding a symlink to the admin user.
     return
 fi
 
@@ -125,8 +125,9 @@ cp .npmrc /Users/administrator
 echo Installing Buildkite agent
 brew tap buildkite/buildkite
 brew install buildkite-agent
-cp /usr/local/etc/buildkite-agent/buildkite-agent.cfg /usr/local/etc/buildkite-agent/buildkite-agent.cfg.orig
-cp buildkite-agent.cfg /usr/local/etc/buildkite-agent/buildkite-agent.cfg
-ln -s /usr/local/etc/buildkite-agent/buildkite-agent.cfg /Users/administrator/buildkite-agent.cfg
-cp environment /usr/local/etc/buildkite-agent/hooks
+PREFIX=`brew --prefix`
+cp $PREFIX/etc/buildkite-agent/buildkite-agent.cfg $PREFIX/etc/buildkite-agent/buildkite-agent.cfg.orig
+cp buildkite-agent.cfg $PREFIX/etc/buildkite-agent/buildkite-agent.cfg
+ln -s $PREFIX/etc/buildkite-agent/buildkite-agent.cfg /Users/administrator/buildkite-agent.cfg
+cp environment $PREFIX/etc/buildkite-agent/hooks
 cp -r expo /Users/administrator

--- a/mac-servers/unity/setup-unity-server.sh
+++ b/mac-servers/unity/setup-unity-server.sh
@@ -17,6 +17,7 @@ echo ==================================
 brew install --cask google-chrome
 brew install --cask textmate
 brew install --cask iterm2
+brew install coreutils
 
 # Clean up the dock
 brew install dockutil


### PR DESCRIPTION
- Install `coreutils` on Unity machines for tools like `realpath`
- Use brew prefix for greater portability