### PR TITLE
Install Firefox and gecko driver for browser automation

### DIFF
--- a/mac-servers/general/setup-server.sh
+++ b/mac-servers/general/setup-server.sh
@@ -16,6 +16,8 @@ echo ==================================
 
 brew install --cask google-chrome
 brew install --cask chromedriver
+brew install --cask firefox
+brew install geckodriver
 xattr -d com.apple.quarantine /usr/local/bin/chromedriver
 brew install --cask textmate
 brew install --cask iterm2


### PR DESCRIPTION
## Goal

Install Firefox and geckodriver, which are must less sensitive from getting out of sync with each other than Chrome and the chromedriver.

This change was rolled our manually some time ago.