### PR TITLE
Update Unity servers to use Java 11

### DIFF
--- a/mac-servers/unity/.gitignore
+++ b/mac-servers/unity/.gitignore
@@ -1,0 +1,3 @@
+# Files stored in S3
+buildkite-agent.cfg
+environment

--- a/mac-servers/unity/setup-unity-server.sh
+++ b/mac-servers/unity/setup-unity-server.sh
@@ -49,8 +49,7 @@ rbenv global 2.7.1
 eval "$(rbenv init -)"
 
 brew tap homebrew/cask
-brew tap AdoptOpenJDK/openjdk
-brew install --cask adoptopenjdk8
+brew install --cask openjdk@11
 
 brew install ninja
 brew install --cask mono-mdk


### PR DESCRIPTION
Update Java on the Unity build servers to 11, from 8.  Java 11 is now needed due to some recent changes to the Android notifier (but 11 also works with other recent branches).

I have manually rolled the change out to the 4 unity servers we currently have.