### PR TITLE
Script driven by launchd to clean up drive space on login

### DIFF
--- a/mac-servers/general/cleanup.sh
+++ b/mac-servers/general/cleanup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+rm -rf /Users/administrator/Library/Developer/CoreSimulator/Devices/*
+rm -rf /Users/administrator/Library/Developer/Xcode/DerivedData
+rm -rf /Users/administrator/Library/Caches/org.carthage.CarthageKit
+npm cache verify

--- a/mac-servers/general/com.bugsnag.cleanup.agent.plist
+++ b/mac-servers/general/com.bugsnag.cleanup.agent.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>Label</key>
+        <string>com.bugsnag.cleanup.agent</string>
+        <key>Program</key>
+        <string>/Users/administrator/scripts/cleanup.sh</string>
+        <key>RunAtLoad</key>
+        <true/>
+    </dict>
+</plist>

--- a/mac-servers/general/setup-server.sh
+++ b/mac-servers/general/setup-server.sh
@@ -133,3 +133,8 @@ cp buildkite-agent.cfg $PREFIX/etc/buildkite-agent/buildkite-agent.cfg
 ln -s $PREFIX/etc/buildkite-agent/buildkite-agent.cfg /Users/administrator/buildkite-agent.cfg
 cp environment $PREFIX/etc/buildkite-agent/hooks
 cp -r expo /Users/administrator
+
+# Install launchd agent to clean up drive space on login
+cp com.bugsnag.cleanup.agent.plist /Users/administrator/Library/LaunchAgents
+mkdir -p /Users/administrator/scripts
+cp cleanup.sh /Users/administrator/scripts


### PR DESCRIPTION
## Goal

Installs a launch agent on new Mac servers to run a script that clears up various locations and caches when it logs in.  

## Testing

I've manually set up the LaunchAgent and script on our existing macOS 11 general purpose servers ands witnessed the free space increase from ~20GB to 100GB after a reboot.