### PR TITLE
Additions needed for Cocoa/Unity on ARM based macOS 12

### DIFF
--- a/mac-servers/unity/setup-unity-server.sh
+++ b/mac-servers/unity/setup-unity-server.sh
@@ -9,6 +9,8 @@ echo ===================
 
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 brew update
+export PATH=/opt/homebrew/bin:$PATH
+export BREW_PREFIX=`brew --prefix`
 
 echo ==================================
 echo Installing admin environment tools
@@ -36,35 +38,49 @@ dockutil --remove 'TV'
 
 # Add items to the dock
 dockutil --add '/Applications/Google Chrome.app'
+dockutil --add '/Applications/iTerm.app'
 
 echo ======================
 echo Installing build tools
 echo ======================
 
+if [[ `uname -m` == "arm64" ]];
+then
+  echo A | softwareupdate --install-rosetta
+fi
+
 brew install rbenv
 brew install ruby-build
+brew install npm
 
-rbenv install 2.7.1
-rbenv global 2.7.1
+rbenv install 2.7.4
+rbenv global 2.7.4
 eval "$(rbenv init -)"
 
 brew tap homebrew/cask
-brew install --cask openjdk@11
 
 brew install ninja
 brew install --cask mono-mdk
-brew install --cask android-sdk
+brew install --cask android-commandlinetools
 
-export ANDROID_HOME=/usr/local/share/android-sdk
-export ANDROID_NDK_HOME=/usr/local/share/android-ndk
+brew install openjdk@11
+export PATH="$BREW_PREFIX/opt/openjdk@11/bin:$PATH"
+
+export ANDROID_HOME=$BREW_PREFIX/share/android-sdk
+export ANDROID_NDK_HOME=$BREW_PREFIX/share/android-ndk
 export PATH="$PATH:/Library/Frameworks/Mono.framework/Versions/Current/Commands"
-sdkmanager --list
-yes | sdkmanager "platforms;android-27"
-yes | sdkmanager --licenses
+yes | $BREW_PREFIX/share/android-commandlinetools/cmdline-tools/homebrew/bin/sdkmanager "platforms;android-27"
+yes | $BREW_PREFIX/share/android-commandlinetools/cmdline-tools/homebrew/bin/sdkmanager --licenses
+
 curl --silent -o ndk.zip https://dl.google.com/android/repository/android-ndk-r16b-darwin-x86_64.zip
 unzip -qq ndk.zip
 mv android-ndk-r16b $ANDROID_NDK_HOME
 rm ndk.zip
+
+echo ==============================
+echo Installing global NPM packages
+echo ==============================
+npm install -g appium # Used to run macOS end-to-end tests
 
 echo ======================
 echo Installing required Gems
@@ -73,6 +89,15 @@ echo ======================
 gem install xcode-install
 gem install fastlane
 gem install cocoapods
+gem install bundler
+
+echo =========================
+echo Installing appium-for-mac
+echo =========================
+curl -L --output AppiumForMac.zip https://github.com/appium/appium-for-mac/releases/download/v0.4.1/AppiumForMac.zip
+unzip AppiumForMac.zip
+rm AppiumForMac.zip
+mv AppiumForMac.app /Applications/AppiumForMac.app
 
 echo =================
 echo Configuring tools
@@ -82,10 +107,6 @@ echo =================
 echo Installing Buildkite agent
 brew tap buildkite/buildkite
 brew install buildkite-agent
-cp /usr/local/etc/buildkite-agent/buildkite-agent.cfg /usr/local/etc/buildkite-agent/buildkite-agent.cfg.orig
-cp buildkite-agent.cfg /usr/local/etc/buildkite-agent/buildkite-agent.cfg
-cp environment /usr/local/etc/buildkite-agent/hooks
-
-brew services start buildkite/buildkite/buildkite-agent
-
-
+cp $BREW_PREFIX/etc/buildkite-agent/buildkite-agent.cfg $BREW_PREFIX/etc/buildkite-agent/buildkite-agent.cfg.orig
+cp buildkite-agent.cfg $BREW_PREFIX/etc/buildkite-agent/buildkite-agent.cfg
+cp environment $BREW_PREFIX/etc/buildkite-agent/hooks


### PR DESCRIPTION
## Goal

Adds setup steps needed for Unity/Cocoa on macOS 12/ARM.

## Design

This is a fairly quick and dirty approach to get things working asap, in light of a proper review of our servers in the new year.

## Testing

Tested by virtue of having set up two new servers this week.